### PR TITLE
Add associatedValues to FieldSpec (for enums); easier construction of CodeBlock

### DIFF
--- a/Sources/CodeGeneration/CodeBlock.swift
+++ b/Sources/CodeGeneration/CodeBlock.swift
@@ -9,19 +9,48 @@
 import Foundation
 
 public struct CodeBlock {
-    public let emittableObjects: [Either<EmitObject, CodeBlock>]
+    
+    private let _builder: CodeBlockBuilder
+    public var emittableObjects: [Either<EmitObject, CodeBlock>] {
+        return _builder.emittableObjects
+    }
 
     public var isEmpty: Bool {
         return emittableObjects.isEmpty
     }
 
     private init(builder: CodeBlockBuilder) {
-        self.emittableObjects = builder.emittableObjects
+        self._builder = builder
     }
 
     public func toString() -> String {
         let codeWriter = CodeWriter()
         return codeWriter.emit(self).out
+    }
+    
+    public func addCodeBlock(codeBlock: CodeBlock) -> CodeBlock {
+        _builder.addCodeBlock(codeBlock)
+        return self
+    }
+    
+    public func addEmitObject(type: EmitType, any: Any? = nil) -> CodeBlock {
+         _builder.addEmitObject(EmitObject(type: type, any: any))
+        return self
+    }
+    
+    public func addLiteral(any: Literal) -> CodeBlock {
+        _builder.addEmitObject(.Literal, any: any)
+        return self
+    }
+    
+    public func addCodeLine(any: Literal) -> CodeBlock {
+        _builder.addEmitObject(.CodeLine, any: any)
+        return self
+    }
+    
+    public func addEmitObjects(emitObjects: [Either<EmitObject, CodeBlock>]) -> CodeBlock {
+        _builder.emittableObjects.appendContentsOf(emitObjects)
+        return self
     }
 
     public static func builder() -> CodeBlockBuilder {

--- a/Sources/Spec/EnumSpec.swift
+++ b/Sources/Spec/EnumSpec.swift
@@ -50,7 +50,6 @@ extension EnumSpecBuilder {
 
     public func addFieldSpec(fieldSpec: FieldSpec) -> Self {
         super.addFieldSpec(internalFieldSpec: fieldSpec)
-        fieldSpec.parentType = .Enum
         return self
     }
 

--- a/Sources/Spec/ExtensionSpec.swift
+++ b/Sources/Spec/ExtensionSpec.swift
@@ -52,7 +52,6 @@ extension ExtensionSpecBuilder {
 
     public func addFieldSpec(fieldSpec: FieldSpec) -> Self {
         super.addFieldSpec(internalFieldSpec: fieldSpec)
-        fieldSpec.parentType = .Enum
         return self
     }
 


### PR DESCRIPTION
1. Add associatedValues to FieldSpec (for enums)
2. Enable easier construction of CodeBlock by encapsulating builder. Now it's possible to call 
`aCodeBlock.addCodeBlock(anotherCodeBlock)`